### PR TITLE
fix brief typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ After forking the project and learning Cyder Programming Standard and Cyder API 
 
 Additionally, the PR should contain the following information:
 
-* A description of each file added/modified/removed and why the modification was performed. Walk me and other reviewers through your thought process for each of these changes. Keep it breif and if further information is required, reviewers will request more information before merging the PR. Try to check the state of your un-merged PR at least bi-weekly so that the modifications you made can be merged in ASAP.
-* A breif summary of your PR and how it affects Cyder. This should differ from the first in that the first is for developers whilst this is simply a summary for users/enthusiasts to monitor Cyder's progress.
+* A description of each file added/modified/removed and why the modification was performed. Walk me and other reviewers through your thought process for each of these changes. Keep it brief and if further information is required, reviewers will request more information before merging the PR. Try to check the state of your un-merged PR at least bi-weekly so that the modifications you made can be merged in ASAP.
+* A brief summary of your PR and how it affects Cyder. This should differ from the first in that the first is for developers whilst this is simply a summary for users/enthusiasts to monitor Cyder's progress.
 
 ## Disclaimers
 


### PR DESCRIPTION
Additionally, the PR should contain the following information:

* A description of each file added/modified/removed and why the modification was performed. Walk me and other reviewers through your thought process for each of these changes. Keep it brief and if further information is required, reviewers will request more information before merging the PR. Try to check the state of your un-merged PR at least bi-weekly so that the modifications you made can be merged in ASAP.
I changed README.md because "brief" was misspelled. I saw the word and thought to myself that it was a travesty that it was misspelled.

* A brief summary of your PR and how it affects Cyder. This should differ from the first in that the first is for developers whilst this is simply a summary for users/enthusiasts to monitor Cyder's progress.
My PR fixes a README.md typo. This does not affect the app.